### PR TITLE
Add instructions for MCP demo submodule

### DIFF
--- a/#00-mcp-your-environment/README.md
+++ b/#00-mcp-your-environment/README.md
@@ -1,1 +1,30 @@
-`cd ./-1-mcp-your-environment/`
+# MCP Your Environment
+
+This directory contains a demo for setting up the Model Context Protocol (MCP) with Claude Desktop and Anaconda.
+
+## Getting Started
+
+The demo is included as a git submodule. To access the demo files, run:
+
+```bash
+git submodule update --init "#00-mcp-your-environment/anaconda-mcp-claude-desktop-demo"
+```
+
+This will populate the `anaconda-mcp-claude-desktop-demo` directory with all the necessary files.
+
+## Demo Contents
+
+Once initialized, you'll find:
+- Setup scripts and environment configuration
+- Sample project demonstrating MCP integration
+- Complete walkthrough documentation
+
+For detailed instructions, see the README.md inside the `anaconda-mcp-claude-desktop-demo` directory after initialization.
+
+## Updating the Demo
+
+To get the latest version of the demo:
+
+```bash
+git submodule update --remote "#00-mcp-your-environment/anaconda-mcp-claude-desktop-demo"
+```


### PR DESCRIPTION
## Summary
- Added clear documentation to the #00-mcp-your-environment README explaining how to initialize and use the MCP demo submodule
- Provides step-by-step instructions for users to access the anaconda-mcp-claude-desktop-demo content

## Context
The MCP demo was already configured as a git submodule in the repository, but the README didn't explain how to initialize it. Users cloning the repo would see an empty directory without knowing they need to run `git submodule update --init` to populate it.

## Changes
- Updated `#00-mcp-your-environment/README.md` with:
  - Overview of what the directory contains
  - Command to initialize the submodule
  - Instructions for updating to the latest version
  - Information about demo contents

## Test plan
- [x] Verified the submodule initializes correctly with the documented command
- [x] Confirmed the README is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)